### PR TITLE
Fixed a build error for the client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,10 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:5000",
+  "options": {
+    "allowedHosts": ["localhost"],
+    "proxy": "https://localhost:5000/"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
Error produced when building the client was
```bash
Invalid options object. Dev Server has been initialized using an options object that does not match the API schema. 
- options.allowedHosts[0] should be a non-empty string.
```

Fix needs testing on other devices.